### PR TITLE
chore(ci): update runners, compilers and checkout action

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.event_name != 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
@@ -45,7 +45,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v2.2.0
         with:
           node-version: '12.x'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,12 +17,14 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: macos-10.15 }
+          - { os: macos-13 }
+          - { os: macos-14 }
+          - { os: macos-15 }
         build: [ Debug, Release ]
 
     name: "${{matrix.config.os}}:${{matrix.build}}"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Configure CMake
         run: cmake -DCMAKE_BUILD_TYPE=${{matrix.build}}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -12,21 +12,41 @@ on:
 
 jobs:
   ubuntu:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.compiler.os }}
     strategy:
       fail-fast: false
       matrix:
         build: [ Debug, Release ]
         compiler:
-          - { cc: "gcc-9", cxx: "g++-9" }
-          - { cc: "gcc-10", cxx: "g++-10" }
-          - { cc: "clang-10", cxx: "clang++-10" }
-          - { cc: "clang-11", cxx: "clang++-11" }
-          - { cc: "clang-12", cxx: "clang++-12" }
+          - { cc: "gcc-11", cxx: "g++-11", os: "ubuntu-22.04" }
+          - { cc: "gcc-12", cxx: "g++-12", os: "ubuntu-22.04" }
+          - { cc: "gcc-13", cxx: "g++-13", os: "ubuntu-24.04" }
+          - { cc: "gcc-14", cxx: "g++-14", os: "ubuntu-24.04" }
+          - { cc: "clang-13", cxx: "clang++-13", os: "ubuntu-22.04" }
+          - { cc: "clang-14", cxx: "clang++-14", os: "ubuntu-22.04" }
+          - { cc: "clang-15", cxx: "clang++-15", os: "ubuntu-22.04" }
+          - { cc: "clang-16", cxx: "clang++-16", os: "ubuntu-24.04" }
+          - { cc: "clang-17", cxx: "clang++-17", os: "ubuntu-24.04" }
+          - { cc: "clang-18", cxx: "clang++-18", os: "ubuntu-24.04" }
 
     name: "${{matrix.compiler.cxx}}:${{matrix.build}}"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+
+      - name: Configure clang
+        run: |
+          if [[ "${{ matrix.compiler.cc }}" == clang* ]]; then
+            sudo apt update
+            sudo apt install ${{ matrix.compiler.cc }} -y
+          fi
+
+      - name: Configure gcc
+        run: |
+          if [[ "${{ matrix.compiler.cc }}" == gcc* ]]; then
+            sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+            sudo apt update
+            sudo apt install ${{ matrix.compiler.cxx }} -y
+          fi
 
       - name: Configure CMake
         run: cmake -DCMAKE_BUILD_TYPE=${{matrix.build}} -DCMAKE_C_COMPILER=${{matrix.compiler.cc}} -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,14 +17,14 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: windows-2016, vs: "Visual Studio 2017" } # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2016-Readme.md#visual-studio-enterprise-2017
-          - { os: windows-2019, vs: "Visual Studio 2019" } # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md#visual-studio-enterprise-2019
+          - { os: windows-2022, vs: "Visual Studio 2022" }
+          - { os: windows-2025, vs: "Visual Studio 2022" }
         build: [ Debug, Release ]
         platform: [ Win32, x64 ]
 
     name: "${{matrix.config.vs}}:${{matrix.platform}}:${{matrix.build}}"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Configure CMake
         run: cmake -A ${{matrix.platform}}


### PR DESCRIPTION
## Summary
- update Windows workflow to use windows-2022 and windows-2025 runners
- expand Ubuntu matrix with newer Ubuntu runners and GCC/Clang versions
- test macOS builds on macos-13 through macos-15
- upgrade all workflows to `actions/checkout@v4`

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: call to non-constexpr function `sysconf`)*

------
https://chatgpt.com/codex/tasks/task_e_68a84b0247cc8320a87e5fcad97ad0d2